### PR TITLE
minor improvement for link creation

### DIFF
--- a/src/MarkdownEdit/Controls/Editor.xaml.cs
+++ b/src/MarkdownEdit/Controls/Editor.xaml.cs
@@ -427,7 +427,7 @@ namespace MarkdownEdit.Controls
 
         public void ExecuteInsertBlockQuote(object sender, ExecutedRoutedEventArgs e) => IfNotReadOnly(() => EditorUtilities.InsertBlockQuote(EditBox));
 
-        public void ExecuteInsertHyperlinkDialog(object sender, ExecutedRoutedEventArgs e) => IfNotReadOnly(() => new InsertHyperlinkDialog {Owner = Application.Current.MainWindow}.ShowDialog());
+        public void ExecuteInsertHyperlinkDialog(object sender, ExecutedRoutedEventArgs e) => IfNotReadOnly(() => new InsertHyperlinkDialog(EditBox.SelectedText) {Owner = Application.Current.MainWindow}.ShowDialog());
 
         public void ExecuteInsertHyperlink(object sender, ExecutedRoutedEventArgs e) => IfNotReadOnly(() => EditorUtilities.InsertHyperlink(EditBox, e.Parameter as string));
 

--- a/src/MarkdownEdit/Controls/InsertHyperlinkDialog.xaml
+++ b/src/MarkdownEdit/Controls/InsertHyperlinkDialog.xaml
@@ -22,9 +22,7 @@
   ShowMinButton="False"
   MinWidth="400">
   <StackPanel Margin="20">
-    <TextBlock>
-      <Run>http://example.com/ "</Run><Run Text="{i18N:Localize insert-hyperlink-optional-title}" />
-      <Run>"</Run></TextBlock>
+    <TextBlock Text="http://example.com/" />
     <TextBox
         x:Name="Link"
         Margin="10"
@@ -34,7 +32,17 @@
         <KeyBinding Command="{x:Static local:InsertHyperlinkDialog.AcceptLinkCommand}" Gesture="Enter" />
       </TextBox.InputBindings>
     </TextBox>
-    </StackPanel>
+    <TextBox
+        x:Name="LinkTitle"
+        controls:TextBoxHelper.Watermark="{i18N:Localize insert-hyperlink-optional-title}"
+        controls:TextBoxHelper.UseFloatingWatermark="True"
+        Margin="10"
+        TabIndex="1">
+      <TextBox.InputBindings>
+        <KeyBinding Command="{x:Static local:InsertHyperlinkDialog.AcceptLinkCommand}" Gesture="Enter" />
+      </TextBox.InputBindings>
+    </TextBox>
+  </StackPanel>
 
   <Window.CommandBindings>
     <CommandBinding Command="Close" Executed="ExecuteClose" />

--- a/src/MarkdownEdit/Controls/InsertHyperlinkDialog.xaml.cs
+++ b/src/MarkdownEdit/Controls/InsertHyperlinkDialog.xaml.cs
@@ -6,19 +6,25 @@ namespace MarkdownEdit.Controls
     {
         public static RoutedCommand AcceptLinkCommand = new RoutedUICommand();
 
-        public InsertHyperlinkDialog()
+        public InsertHyperlinkDialog(string selectedText)
         {
             InitializeComponent();
             Link.Focus();
             Link.SelectAll();
+            LinkTitle.Text = selectedText;
             CommandBindings.Add(new CommandBinding(AcceptLinkCommand, ExecuteAcceptLinkCommand));
         }
 
         private void ExecuteAcceptLinkCommand(object sender, ExecutedRoutedEventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(Link.Text))
+            var linkText = Link.Text;
+            if (!string.IsNullOrWhiteSpace(linkText))
             {
-                MainWindow.InsertHyperlinkCommand.Execute(Link.Text, Owner);
+                if (!string.IsNullOrWhiteSpace(LinkTitle.Text))
+                {
+                    linkText = $"{linkText} \"{LinkTitle.Text}\"";
+                }
+                MainWindow.InsertHyperlinkCommand.Execute(linkText, Owner);
             }
             Close();
         }


### PR DESCRIPTION
this is only a minor improvement to the existing link creation dialog, but i thought i would be nice for better usage.

before
![cool01](https://cloud.githubusercontent.com/assets/658431/13035519/87ddb316-d352-11e5-8eac-07060d578dee.gif)

after
![cool02](https://cloud.githubusercontent.com/assets/658431/13035520/8fa64838-d352-11e5-9179-f9f0e2d60a60.gif)

or (with selected text)
![cool03](https://cloud.githubusercontent.com/assets/658431/13035522/966e9bca-d352-11e5-8ea7-cf1cf5cb3033.gif)
