### PR TITLE
Fix tweet link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Markdown Edit
 status](https://ci.appveyor.com/api/projects/status/bqawxp5t4615y25s?svg=true)](https://ci.appveyor.com/project/mike-ward/markdown-edit)
 [![Join the chat at
 https://gitter.im/mike-ward/Markdown-Edit](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mike-ward/Markdown-Edit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Twitter](https://img.shields.io/twitter/url/https/github.com/mike-ward/Markdown-Edit.svg?style=social)](https://twitter.com/intent/tweet?text=Wow:&url=%5Bobject%20Object%5D)
+[![Twitter](https://img.shields.io/twitter/url/https/github.com/mike-ward/Markdown-Edit.svg?style=social)](https://twitter.com/intent/tweet?text=Wow:&url=http://markdownedit.com)
 
 [![Release](https://img.shields.io/github/release/mike-ward/Markdown-Edit.svg?style=flat-square)](https://github.com/mike-ward/Markdown-Edit/releases/latest)
 [![GitHub issues](https://img.shields.io/github/issues/mike-ward/Markdown-Edit.svg)](https://github.com/mike-ward/Markdown-Edit/issues)


### PR DESCRIPTION
Stumbled upon this issue and fixed it by setting the reference-URL of the tweet to http://markdownedit.com/