### PR TITLE
Fixed https://github.com/mike-ward/Markdown-Edit/issues/231

### DIFF
--- a/src/MarkdownEdit/Models/AbstractSyntaxTree.cs
+++ b/src/MarkdownEdit/Models/AbstractSyntaxTree.cs
@@ -86,7 +86,7 @@ namespace MarkdownEdit.Models
             }
         }
 
-        public static bool PositionSafeForSmartLink(Block ast, int start, int length)
+        public static bool PositionSafeForSmartLink(Block ast, int start, int length, InlineTag[] ignoreInlines = null)
         {
             if (ast == null) return true;
             var end = start + length;
@@ -108,7 +108,7 @@ namespace MarkdownEdit.Models
                 return !EnumerateInlines(block.InlineContent)
                     .TakeWhile(il => il.SourcePosition < end)
                     .Where(il => il.SourcePosition + il.SourceLength > start)
-                    .Any(il => inlineTags.Any(tag => tag == il.Tag));
+                    .Any(il => inlineTags.Any(tag => tag == il.Tag && (!ignoreInlines?.Contains(tag) ?? true)));
             }
             return true;
         }

--- a/src/MarkdownEdit/SpellCheck/SpellCheckProvider.cs
+++ b/src/MarkdownEdit/SpellCheck/SpellCheckProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using CommonMark.Syntax;
 using ICSharpCode.AvalonEdit.Document;
 using ICSharpCode.AvalonEdit.Rendering;
 using MarkdownEdit.Controls;
@@ -109,7 +110,7 @@ namespace MarkdownEdit.SpellCheck
                 var textWithout = originalText;
                 if (userSettings.SpellCheckIgnoreCodeBlocks)
                 {
-                    if (!AbstractSyntaxTree.PositionSafeForSmartLink(_editor.AbstractSyntaxTree, startOfLine, lengthOfLine))
+                    if (!AbstractSyntaxTree.PositionSafeForSmartLink(_editor.AbstractSyntaxTree, startOfLine, lengthOfLine, new InlineTag[] { InlineTag.Code }))
                     {
                         // Generally speaking, if it's not safe to insert a link, it's probably something we don't
                         // want spell checked.


### PR DESCRIPTION
Wasn't sure how to add it in without code duplication. This should be a transparent fix, not affecting any other code that refers to `PositionSafeForSmartLink`. This is my first actual PR, sorry if something's out of place.